### PR TITLE
Fix initialize() method to properly check CLI condition on windows la…

### DIFF
--- a/src/model/ApplicationManager.php
+++ b/src/model/ApplicationManager.php
@@ -224,7 +224,7 @@ class ApplicationManager
 
     public function initialize()
     {
-        if (isset($_SERVER['SHELL']) || isset($_SERVER['SHLVL'])) {
+        if (isset($_SERVER['SHELL']) || isset($_SERVER['SHLVL']) || defined('STDIN')) {
             $this->registerCommands();
             $this->registerCleanupCallbacks();
             $this->registerHermesHandlers();


### PR DESCRIPTION
…ragon

Added defined('STDIN') because condition on Windows PHP CLI didnt fire. Inspired by https://www.binarytides.com/php-check-running-cli/