### PR TITLE
Extended cleanup functionality

### DIFF
--- a/src/ApplicationModule.php
+++ b/src/ApplicationModule.php
@@ -31,14 +31,6 @@ class ApplicationModule extends CrmModule
         $commandsContainer->registerCommand($this->getInstance(\Crm\ApplicationModule\Commands\InstallAssetsCommand::class));
     }
 
-    public function registerCleanupFunction(CallbackManagerInterface $cleanUpManager)
-    {
-        $cleanUpManager->add(function (Container $container) {
-            //            $hermesTaskRepository = $container->getByType(\Crm\ApplicationModule\Repository\HermesTasksRepository::class);
-//            $hermesTaskRepository->removeOldData();
-        });
-    }
-
     public function registerApiCalls(ApiRoutersContainerInterface $apiRoutersContainer)
     {
         $apiRoutersContainer->attachRouter(new ApiRoute(

--- a/src/model/CallbackManagerInterface.php
+++ b/src/model/CallbackManagerInterface.php
@@ -7,7 +7,9 @@ use Nette\DI\Container;
 
 interface CallbackManagerInterface
 {
-    public function add(Closure $callback);
+    public function add(string $key, Closure $callback);
+
+    public function remove(string $key);
 
     public function execAll(Container $container);
 }

--- a/src/model/CleanUpManager.php
+++ b/src/model/CleanUpManager.php
@@ -9,9 +9,17 @@ class CleanUpManager implements CallbackManagerInterface
 {
     private $callbacks = [];
 
-    public function add(Closure $callback)
+    public function add(string $key, Closure $callback)
     {
-        $this->callbacks[] = $callback;
+        $this->callbacks[$key] = $callback;
+        return $this;
+    }
+
+    public function remove(string $key)
+    {
+        if (!empty($this->callbacks[$key])) {
+            unset($this->callbacks[$key]);
+        }
         return $this;
     }
 


### PR DESCRIPTION
I was looking for a way to remove/change one of the cleanup functions, but I did not found one. This is a breaking change, but with these changes the cleanups could be better maintained. Registration in the module classes could look like this:
```
$cleanUpManager->add(PaymentLogsRepository::class, function (Container $container) {
    $paymentsLogsRepository = $container->getByType(PaymentLogsRepository::class);
    $paymentsLogsRepository->removeOldData();
});
```
Removal:
```
$cleanUpManager->remove(PaymentLogsRepository::class);
```
Cleanups could be also overridden with a different time period:
```
$cleanUpManager->add(PaymentLogsRepository::class, function (Container $container) {
    $paymentsLogsRepository = $container->getByType(PaymentLogsRepository::class);
    $paymentsLogsRepository->removeOldData('-6 months');
});
```