### PR TITLE
feat: allow  monolog 2 to be used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "vlucas/phpdotenv": "^5.3",
     "tomaj/hermes": "^4.0",
     "predis/predis": "^1.0",
-    "monolog/monolog": "^1.23",
+    "monolog/monolog": "^1.23|^2.3",
     "contributte/forms-multiplier": "^3.2",
     "composer/composer": "^2.0",
     "malkusch/lock": "^2.1",


### PR DESCRIPTION
This change allows to use both Monolog 1.x and Monolog 2.x.
We have a CRM application where we started to require Monolog 2 and we need this change.
@mikoczy 
@lulco 