### PR TITLE
fix exception

### DIFF
--- a/src/Forms/BootstrapSmallInlineFormRenderer.php
+++ b/src/Forms/BootstrapSmallInlineFormRenderer.php
@@ -13,7 +13,7 @@ use Nette\Forms\Rendering\DefaultFormRenderer;
 
 class BootstrapSmallInlineFormRenderer extends DefaultFormRenderer
 {
-    public $wrappers = [
+    public array $wrappers = [
         'form' => [
             'container' => '',
         ],

--- a/src/Presenters/SnippetsPresenter.php
+++ b/src/Presenters/SnippetsPresenter.php
@@ -4,7 +4,7 @@ namespace Crm\ApplicationModule\Presenters;
 
 class SnippetsPresenter extends FrontendPresenter
 {
-    public $autoCanonicalize = false;
+    public bool $autoCanonicalize = false;
 
     public function renderDefault($key = 'default')
     {


### PR DESCRIPTION
fix:

./bin/command.php

1: <?php
2:
3: namespace Crm\ApplicationModule\Presenters;
4:
5: class SnippetsPresenter extends FrontendPresenter
6: {
7: public $autoCanonicalize = false;
8:
9: public function renderDefault($key = 'default')
10: {
11: $this->template->key = $key;
12: }
13: }

ErrorException: Type of Crm\ApplicationModule\Presenters\SnippetsPresenter::$autoCanonicalize must be bool (as in class Nette\Application\UI\Presenter) in /www/crm/www/vendor/remp/crm-application-module/src/Presenters/SnippetsPresenter.php:5
Stack trace:
#0 [internal function]: Tracy\Debugger::shutdownHandler()
https://github.com/remp2020/crm-application-module/pull/1 {main}

(stored in /www/crm/www/log/exception--2024-03-21--08-47--047859dc9d.html)